### PR TITLE
Update Vite base path to root

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,5 +6,5 @@ export default defineConfig({
   plugins: [
     tailwindcss(),
     react(),
-  ],base: "/portfolio-KayoWeiber/",
+  ],base: "/",
 });


### PR DESCRIPTION
Changed the Vite config base path from '/portfolio-KayoWeiber/' to '/'. This allows the app to be served from the root URL instead of a subdirectory.